### PR TITLE
Improving detection of whether /g?cc/ is clang on Darwin

### DIFF
--- a/t/03-configure.t
+++ b/t/03-configure.t
@@ -25,6 +25,8 @@ subtest 'gcc' => sub {
 };
 
 subtest 'darwin clang/gcc homebrew' => sub {
+  plan skip_all => 'Mocking does not work on MSWin32'
+    if $^O eq 'MSWin32';
   local $Alien::OpenMP::configure::CCNAME = 'gcc';
   local $Alien::OpenMP::configure::OS     = 'darwin';
   local $ENV{PATH}                        = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";


### PR DESCRIPTION
* openmp 5.1 is on my machine so adding in the newer specs
* testing compiler with some preprocessor macros
* switching to `$Config::Config{cc}` from `$Config::Config{ccname}` as ExtUtils::CBuilder uses this
  - Using `basename` should help here too.
* homebrew does not symlink openmp into /usr/local everywhere.

relates-to: Perl-OpenMP/p5-Alien-OpenMP#28